### PR TITLE
PR: Update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This component is no longer maintained by @corbanmailloux and still doesn't seem to completely work even after this commit.
+
 # Package Concierge Scraper Component for Home Assistant
 
 Home Assistant custom component for [Package Concierge](https://packageconciergeadmin.com) that can login and get a count (maximum 5) of packages waiting to be picked up from the Package Concierge package locker system.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
+WARNING WARNING WARNING WARNING WARNING WARNING 
+
 This component is no longer maintained by @corbanmailloux and still doesn't seem to completely work even after this commit.
+
+WARNING WARNING WARNING WARNING WARNING WARNING 
+
 
 # Package Concierge Scraper Component for Home Assistant
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-WARNING WARNING WARNING WARNING WARNING WARNING 
-
-This component is no longer maintained by @corbanmailloux and still doesn't seem to completely work even after this commit.
-
-WARNING WARNING WARNING WARNING WARNING WARNING 
-
-
 # Package Concierge Scraper Component for Home Assistant
+
+**This component is not currently maintained**
 
 Home Assistant custom component for [Package Concierge](https://packageconciergeadmin.com) that can login and get a count (maximum 5) of packages waiting to be picked up from the Package Concierge package locker system.
 It also supports multiple users by registering multiple sensors.

--- a/custom_components/package_concierge/manifest.json
+++ b/custom_components/package_concierge/manifest.json
@@ -3,6 +3,7 @@
     "name": "Package Concierge",
     "documentation": "https://github.com/corbanmailloux/package-concierge-hass",
     "issue_tracker": "https://github.com/corbanmailloux/package-concierge-hass/issues",
+    "loggers": ["custom_components.package_concierge"],
     "requirements": [
         "requests",
         "beautifulsoup4"

--- a/custom_components/package_concierge/sensor.py
+++ b/custom_components/package_concierge/sensor.py
@@ -95,7 +95,7 @@ class PackageConciergeScraper:
     def update(self):
         _LOGGER.debug(f"Package Concierge running update for: {self._username}")
 
-        login_url = "https://packageconciergeadmin.com/Login.aspx"
+        login_url = "https://packageconciergeadmin.com/Community/CommunityDashboard.aspx"
 
         # Create a persistent session for cookies.
         session = requests.Session()


### PR DESCRIPTION
# Changes in this PR

- Added note to README.md indicating component is not currently maintained per #1 comments from repo owner
- Altered URL from `packageconciergeadmin.com/Welcome.aspx` to `packageconciergeadmin.com/Community/CommunityDashboard.aspx`; seems to fix a log message indicating component was not logging in correctly
- Adjusted logging in manifest

NOTES:

- Adjusted logging in manifest per https://github.com/home-assistant/core/issues/84489
- Additional testing will be performed to confirm this fix actually fixes things, but package counts seem to be reported correctly on an examination
- It's possible None shouldn't be the uninitialized value of `number_of_packages` since this has the sensor reporting an 'Unknown' state which may not be the intended behavior